### PR TITLE
Added JSON support

### DIFF
--- a/bin/public_ip
+++ b/bin/public_ip
@@ -10,7 +10,7 @@ class App
 
   main do |service|
     if options['list-services']
-      list_of_services = PublicIp.list_services.map do |service_symbol, service_class|
+      list_of_services = PublicIp.list_services.sort.map do |service_symbol, service_class|
         "#{service_symbol} (#{service_class.uri})"
       end.join("\n")
 

--- a/features/public_ip.feature
+++ b/features/public_ip.feature
@@ -30,11 +30,13 @@ Feature: PublicIp CLI application
       ip_echo (http://ipecho.net/plain)
       ip_info (http://ipinfo.io/ip)
       ip_ogre (http://ipogre.com)
+      ipify (http://api.ipify.org/?format=json)
       mx_toolbox (http://mxtoolbox.com/WhatIsMyIP/)
       private_internet_access (https://www.privateinternetaccess.com/pages/whats-my-ip/)
       smart_ip (http://smart-ip.net/myip)
       what_is_my_ip (https://www.whatismyip.com/)
       what_is_my_ip_address (http://bot.whatismyipaddress.com)
+      wtf_is_my_ip (http://wtfismyip.com/json)
       You may pick a service and run public_ip [service] to get your IP address from that service
       """
 

--- a/lib/public_ip.rb
+++ b/lib/public_ip.rb
@@ -4,6 +4,7 @@ require 'public_ip/service/simple'
 require 'public_ip/service/parsed_html'
 require 'public_ip/service/plain'
 require 'public_ip/service/matched_expression'
+require 'public_ip/service/json_type'
 
 require 'public_ip/version'
 

--- a/lib/public_ip/service/ipify.rb
+++ b/lib/public_ip/service/ipify.rb
@@ -1,0 +1,13 @@
+module PublicIp
+  module Service
+    class Ipify < JsonType
+      def self.uri
+        URI('http://api.ipify.org/?format=json')
+      end
+
+      def self.parse_json(json_data)
+        json_data['ip']
+      end
+    end
+  end
+end

--- a/lib/public_ip/service/json_type.rb
+++ b/lib/public_ip/service/json_type.rb
@@ -1,0 +1,19 @@
+require 'json'
+
+module PublicIp
+  module Service
+    class JsonType < Simple
+      extend PublicIp::Service::Registrable
+
+      def self.parse_json(_json_data)
+        fail 'Not implemented'
+      end
+
+      def self.ip
+        response = perform_request
+
+        parse_json(JSON.parse(response.body.strip))
+      end
+    end
+  end
+end

--- a/lib/public_ip/service/wtf_is_my_ip.rb
+++ b/lib/public_ip/service/wtf_is_my_ip.rb
@@ -1,0 +1,13 @@
+module PublicIp
+  module Service
+    class WtfIsMyIp < JsonType
+      def self.uri
+        URI('http://wtfismyip.com/json')
+      end
+
+      def self.parse_json(json_data)
+        json_data['YourFuckingIPAddress']
+      end
+    end
+  end
+end

--- a/spec/provider/json_type_spec.rb
+++ b/spec/provider/json_type_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+module PublicIp
+  module Service
+    class JSONTypeService < JsonType
+      def self.uri
+        URI('http://www.example.com/json')
+      end
+
+      def self.parse_json(resp)
+        resp['ExampleIP']
+      end
+
+      def self.headers
+        { 'User-Agent' => 'rspec - testing public_ip via json response', 'Content-Type' => 'application/json' }
+      end
+    end
+  end
+end
+
+describe PublicIp::Service::JSONTypeService do
+  describe '.ip' do
+    before do
+      stub_request(:get, /.*/)
+        .with(headers: described_class.headers)
+        .to_return(status: 200, body: "{\"ExampleIP\": \"127.0.0.1\"}\n", headers: {})
+    end
+
+    it 'strips the response body, parses json, and returns the ip address' do
+      expect(described_class.ip).to eq('127.0.0.1')
+    end
+  end
+end


### PR DESCRIPTION
I added two new services (ipify.org and wtfismyip.com), and support their json response types. As of now using their https prefix doesn't work, so I resorted to using http. 
